### PR TITLE
Add default to get_site_option() calls.

### DIFF
--- a/php/regions/class-network-settings.php
+++ b/php/regions/class-network-settings.php
@@ -158,7 +158,6 @@ class Network_Settings extends Region {
 	 * Get the value for the setting
 	 * 
 	 * @param string $name
-	 * @param mixed $default
 	 * @return mixed
 	 */
 	public function get( $name ) {

--- a/php/regions/class-network-settings.php
+++ b/php/regions/class-network-settings.php
@@ -158,6 +158,7 @@ class Network_Settings extends Region {
 	 * Get the value for the setting
 	 * 
 	 * @param string $name
+	 * @param mixed $default
 	 * @return mixed
 	 */
 	public function get( $name ) {
@@ -166,22 +167,22 @@ class Network_Settings extends Region {
 			$name = $this->options_map[ $name ];
 		}
 
-		$value = get_site_option( $name );
-
 		// Data transformation if we need to
 		switch ( $name ) {
 			case 'allowedthemes':
 			case 'active_sitewide_plugins':
-				$value = array_keys( $value );
+				# Coerce to array of names
+				return array_keys( get_site_option($name, array() ) );
 				break;
 
 			case 'registrationnotification':
-				$value = ( 'yes' === $value ) ? true : false;
+				# Coerce to boolean
+				return ( 'yes' === get_site_option( $name ) );
 				break;
+			default:
+				return get_site_option( $name );
 
 		}
-
-		return $value;
 
 	}
 


### PR DESCRIPTION
When there are no network-wide themes or plugins, get_site_option() returns its second parameter, which defaults to FALSE.  The original code produces a compile-time warning because the array_keys() function expects its first parameter to be an array, not FALSE.

My changes:

* Move the get_site_option() call inside the switch() statement.
* Set the get_site_option() default to array() where an array is expected.
* Return the result directly instead of assigning to an intermediate variable.