### PR TITLE
Patch 3

### DIFF
--- a/php/regions/class-region.php
+++ b/php/regions/class-region.php
@@ -126,14 +126,14 @@ abstract class Region {
 					$prototype_vals = call_user_func( array( $this, $schema['_get_callback'] ), $this->current_schema_attribute );
 
 					$data = array();
-					if ( is_array($prototype_vals) ) {
-						foreach( $prototype_vals as $prototype_val ) {
-							$this->current_schema_attribute = $prototype_val;
-
-							$this->current_schema_attribute_parents[] = $prototype_val;
-							$data[ $prototype_val ] = $this->recursively_get_current_data( $schema['_prototype'] );
-							array_pop( $this->current_schema_attribute_parents );
-						}
+					if ( ! is_array($prototype_vals) ) {
+						$prototype_vals = array();
+					}
+					foreach( $prototype_vals as $prototype_val ) {
+						$this->current_schema_attribute = $prototype_val;
+						$this->current_schema_attribute_parents[] = $prototype_val;
+						$data[ $prototype_val ] = $this->recursively_get_current_data( $schema['_prototype'] );
+						array_pop( $this->current_schema_attribute_parents );
 					}
 					return $data;
 				}

--- a/php/regions/class-region.php
+++ b/php/regions/class-region.php
@@ -126,13 +126,14 @@ abstract class Region {
 					$prototype_vals = call_user_func( array( $this, $schema['_get_callback'] ), $this->current_schema_attribute );
 
 					$data = array();
-					foreach( $prototype_vals as $prototype_val ) {
-						$this->current_schema_attribute = $prototype_val;
+					if ( is_array($prototype_vals) ) {
+						foreach( $prototype_vals as $prototype_val ) {
+							$this->current_schema_attribute = $prototype_val;
 
-						$this->current_schema_attribute_parents[] = $prototype_val;
-						$data[ $prototype_val ] = $this->recursively_get_current_data( $schema['_prototype'] );
-						array_pop( $this->current_schema_attribute_parents );
-
+							$this->current_schema_attribute_parents[] = $prototype_val;
+							$data[ $prototype_val ] = $this->recursively_get_current_data( $schema['_prototype'] );
+							array_pop( $this->current_schema_attribute_parents );
+						}
 					}
 					return $data;
 				}

--- a/php/regions/class-region.php
+++ b/php/regions/class-region.php
@@ -131,9 +131,11 @@ abstract class Region {
 					}
 					foreach( $prototype_vals as $prototype_val ) {
 						$this->current_schema_attribute = $prototype_val;
+
 						$this->current_schema_attribute_parents[] = $prototype_val;
 						$data[ $prototype_val ] = $this->recursively_get_current_data( $schema['_prototype'] );
 						array_pop( $this->current_schema_attribute_parents );
+
 					}
 					return $data;
 				}


### PR DESCRIPTION
Skip the foreach() loop when $prototype_vals is a non-array, as when get_sites() returns NULL.