### PR TITLE
Add support for timezone and language.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ behat.phar
 composer.phar
 /vendor
 .DS_Store
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,17 @@ language: php
 dist: precise
 
 php:
-    - 5.3
-    - 5.5
+    - 5.6
 
 env:
     global:
-         - WP_CLI_BIN_DIR=/tmp/wp-cli-phar
-         - WP_CLI_CONFIG_PATH=/tmp/wp-cli-phar/config.yml
+         - WP_CLI_BIN_DIR=/home/travis/.composer/vendor/bin
+         - WP_CLI_CONFIG_PATH=/tmp/config.yml
 
 before_script:
+    - composer global require mustangostang/spyc
+    - composer global require wp-cli/wp-cli-bundle
+    - export PATH="$HOME/.composer/vendor/bin:$PATH"
     - bash bin/install-package-tests.sh
 
 script: ./vendor/bin/behat

--- a/bin/install-package-tests.sh
+++ b/bin/install-package-tests.sh
@@ -4,16 +4,6 @@ set -ex
 
 PACKAGE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
 
-install_wp_cli() {
-
-	# the Behat test suite will pick up the executable found in $WP_CLI_BIN_DIR
-	mkdir -p $WP_CLI_BIN_DIR
-	wget https://github.com/wp-cli/builds/raw/gh-pages/phar/wp-cli-nightly.phar
-	mv wp-cli-nightly.phar $WP_CLI_BIN_DIR/wp
-	chmod +x $WP_CLI_BIN_DIR/wp
-
-}
-
 set_package_context() {
 
 	touch $WP_CLI_CONFIG_PATH
@@ -40,7 +30,6 @@ install_db() {
 	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 }
 
-install_wp_cli
 set_package_context
 download_behat
 install_db

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "require": {
-        "wp-cli/mustangostang-spyc": "^0.6.3"
+        "php": ">=5.6"
     },
     "autoload": {
         "files": [ "dictator.php" ]

--- a/features/network-sites.feature
+++ b/features/network-sites.feature
@@ -12,10 +12,15 @@ Feature: Network Sites Region
           active_theme: p2
           active_plugins:
             - akismet/akismet.php
+          timezone_string: Europe/London
+          WPLANG: en_GB
       """
 
     When I run `wp plugin install akismet --force`
     And I run `wp theme install p2 --force`
+    Then STDOUT should not be empty
+
+    When I run `wp language core install en_GB`
     Then STDOUT should not be empty
 
     When I run `wp dictator impose network-state.yml`
@@ -46,3 +51,15 @@ Feature: Network Sites Region
     Then STDOUT should be a table containing rows:
       | name     | status            |
       | akismet  | active            |
+
+    When I run `wp --url=example.com/enolagay option get timezone_string`
+    Then STDOUT should be:
+      """
+      Europe/London
+      """
+
+    When I run `wp --url=example.com/enolagay option get WPLANG`
+    Then STDOUT should be:
+      """
+      en_GB
+      """

--- a/features/site-settings.feature
+++ b/features/site-settings.feature
@@ -22,10 +22,15 @@ Feature: Site Settings Region
         show_on_front: page
         page_on_front: 1
         page_for_posts: 2
+        timezone: Europe/London
+        WPLANG: en_GB
       """
 
     When I run `wp plugin install akismet --force`
     And I run `wp theme install p2 --force`
+    Then STDOUT should not be empty
+
+    When I run `wp language core install en_GB`
     Then STDOUT should not be empty
 
     When I run `wp dictator impose site-state.yml`
@@ -91,4 +96,16 @@ Feature: Site Settings Region
     Then STDOUT should be:
       """
       2
+      """
+
+    When I run `wp option get timezone_string`
+    Then STDOUT should be:
+      """
+      Europe/London
+      """
+
+    When I run `wp option get WPLANG`
+    Then STDOUT should be:
+      """
+      en_GB
       """

--- a/php/class-dictator-translator.php
+++ b/php/class-dictator-translator.php
@@ -90,7 +90,10 @@ class Translator {
 								continue;
 							}
 
-							$this->recursively_validate_state_data( $child_schema, $child_data[ $schema_key ] );
+							$this->recursively_validate_state_data(
+								$child_schema,
+								isset( $child_data[ $schema_key ] ) ? $child_data[ $schema_key ] : null
+							);
 						}
 
 					}
@@ -112,7 +115,10 @@ class Translator {
 
 						$this->current_schema_attribute = $attribute;
 
-						$this->recursively_validate_state_data( $attribute_schema, $state_data[ $attribute ] );
+						$this->recursively_validate_state_data(
+							$attribute_schema,
+							isset( $state_data[ $attribute ] ) ? $state_data[ $attribute ] : null
+						);
 
 					}
 

--- a/php/regions/class-network-sites.php
+++ b/php/regions/class-network-sites.php
@@ -39,6 +39,16 @@ class Network_Sites extends Region {
 						'_required'         => false,
 						'_get_callback'     => 'get_site_value',
 						),
+					'timezone_string' => array(
+						'_type'             => 'text',
+						'_required'         => false,
+						'_get_callback'     => 'get_site_value',
+						),
+					'WPLANG' => array(
+						'_type'             => 'text',
+						'_required'         => false,
+						'_get_callback'     => 'get_site_value',
+						),
 					)
 				)
 		);
@@ -140,6 +150,17 @@ class Network_Sites extends Region {
 
 					break;
 
+				case 'WPLANG':
+
+					add_network_option( $site['blog_id'], $field, $single_value );
+					break;
+
+				default:
+
+					update_option( $field, $single_value );
+
+					break;
+
 			}
 
 		}
@@ -227,6 +248,14 @@ class Network_Sites extends Region {
 				foreach( $site_users as $site_user ) {
 					$value[ $site_user->user_login ] = array_shift( $site_user->roles );
 				}
+				break;
+
+			case 'WPLANG':
+				$value = get_network_option( $site['blog_id'], $key );
+				break;
+
+			default:
+				$value = get_option( $key );
 				break;
 
 		}

--- a/php/regions/class-site-settings.php
+++ b/php/regions/class-site-settings.php
@@ -30,6 +30,11 @@ class Site_Settings extends Region {
 				'_required'         => false,
 				'_get_callback'     => 'get',
 				),
+			'WPLANG' => array(
+				'_type'             => 'text',
+				'_required'         => false,
+				'_get_callback'     => 'get',
+				),
 			'date_format'   => array(
 				'_type'             => 'text',
 				'_required'         => false,


### PR DESCRIPTION
* Adds support for timezone and languages
* Makes changes to get tests running and thus the build passing
* Adds some tests for timezone and languages
* Ups minimum support PHP version to 5.6 (inline with wp-cli)

I did this a while ago but never contributed it back, but finally got round to it! Not sure if this project is still even maintained or not, but I love it and we use it quite a bit so I hope so. Anyhow, here's a PR, hope it's of use. Thanks!