### PR TITLE
Replace deprecated function.

### DIFF
--- a/php/regions/class-network-sites.php
+++ b/php/regions/class-network-sites.php
@@ -102,7 +102,7 @@ class Network_Sites extends Region {
 			}
 		}
 
-		switch_to_blog( $site['blog_id'] );
+		switch_to_blog( $site->blog_id );
 		foreach( $value as $field => $single_value ) {
 
 			switch ( $field ) {
@@ -145,14 +145,14 @@ class Network_Sites extends Region {
 							continue;
 						}
 
-						add_user_to_blog( $site['blog_id'], $user->ID, $role );
+						add_user_to_blog( $site->blog_id, $user->ID, $role );
 					}
 
 					break;
 
 				case 'WPLANG':
 
-					add_network_option( $site['blog_id'], $field, $single_value );
+					add_network_option( $site->blog_id, $field, $single_value );
 					break;
 
 				default:
@@ -191,7 +191,7 @@ class Network_Sites extends Region {
 		}	
 		do {
 
-			$sites_results = wp_get_sites( $args );
+			$sites_results = get_sites( $args );
 			$sites = array_merge( $sites, $sites_results );
 
 			$args['offset'] += $args['limit'];
@@ -201,9 +201,9 @@ class Network_Sites extends Region {
 		$this->sites = array();
 		foreach( $sites as $site ) {
 			if ( is_subdomain_install() ) {
-				$site_slug = str_replace( '.' . get_current_site()->domain, '', $site['domain'] );
+				$site_slug = str_replace( '.' . get_current_site()->domain, '', $site->domain );
 			} else {
-				$site_slug = trim( $site['path'], '/' );
+				$site_slug = trim( $site->path, '/' );
 			}
 			$this->sites[ $site_slug ] = $site;
 		}
@@ -221,7 +221,7 @@ class Network_Sites extends Region {
 		$site_slug = $this->current_schema_attribute_parents[0];
 		$site = $this->get_site( $site_slug );
 
-		switch_to_blog( $site['blog_id'] );
+		switch_to_blog( $site->blog_id );
 
 		switch ( $key ) {
 
@@ -251,7 +251,7 @@ class Network_Sites extends Region {
 				break;
 
 			case 'WPLANG':
-				$value = get_network_option( $site['blog_id'], $key );
+				$value = get_network_option( $site->blog_id, $key );
 				break;
 
 			default:
@@ -301,7 +301,7 @@ class Network_Sites extends Region {
 	 * Get a site by its slug
 	 * 
 	 * @param string $slug
-	 * @return array|false
+	 * @return WP_Site|false
 	 */
 	protected function get_site( $site_slug ) {
 


### PR DESCRIPTION
`wp_get_sites()` is deprecated (since 4.6) and thus leaves a bit of
noise in the output when running dictator against a network. This uses
the replacment function and makes the necessary adjustments.

@danielbachhuber I know this project isn't maintained anymore, so let me know if you think we're better off creating a fork for these updates, as there's likely more we'd like to make in the future too. Thanks!